### PR TITLE
fix: misspelling in custom env

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -17,7 +17,7 @@
     "logging": "DB_LOGGING",
     "synchronize": "DB_SYNCHRONIZE",
     "enableSslAuth": "DB_SSL_ENABLE",
-    "ssl": {
+    "sslPaths": {
       "ca": "DB_SSL_CA",
       "key": "DB_SSL_KEY",
       "cert": "DB_SSL_CERT"


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |

Further  information:
There was a misspelling in the custom environment variables file.
